### PR TITLE
Fix error icon in upload failure alert

### DIFF
--- a/src/components/pages/images/AddImage.js
+++ b/src/components/pages/images/AddImage.js
@@ -78,7 +78,7 @@ const AddImage = () => {
                 if (err) {
                     Swal.fire({
                         position: 'top-end',
-                        icon: 'success',
+                        icon: 'error',
                         title: 'Upload Failed',
                         titleText: err,
                         showConfirmButton: false,


### PR DESCRIPTION
@sourcery-ai review

## Summary by Sourcery

Bug Fixes:
- Correct the icon displayed in the upload failure alert from 'success' to 'error'.